### PR TITLE
Annotate user objects with consensys, web3studio, or not

### DIFF
--- a/packages/github-collector/package.json
+++ b/packages/github-collector/package.json
@@ -21,6 +21,7 @@
     "@octokit/graphql": "^2.0.2",
     "common-tags": "^2.0.0-alpha.1",
     "dotenv": "^7.0.0",
+    "lodash": "^4.17.11",
     "p-do-whilst": "^1.0.0",
     "rxjs": "^6.4.0",
     "winston": "^3.2.1",

--- a/packages/github-collector/src/annotateUsers.js
+++ b/packages/github-collector/src/annotateUsers.js
@@ -1,0 +1,55 @@
+const { from, combineLatest } = require('rxjs');
+const { map } = require('rxjs/operators');
+const organizationMembers = require('./queries/organizationMembers');
+const organizationTeamMembers = require('./queries/organizationTeamMembers');
+const _ = require('lodash');
+
+/**
+ * Augment user objects found in events
+ *
+ * @returns {Function} Observable Function
+ */
+module.exports = () => source => {
+  // Source of all consensys members as an array of IDs
+  const consensysMembers = combineLatest(
+    from(organizationMembers('consensys')),
+    from(organizationMembers('trufflesuite')),
+    from(organizationMembers('infura'))
+  ).pipe(
+    map(orgs =>
+      _(orgs)
+        .flatMap(org => org.map(user => user.node.id))
+        .uniq()
+        .value()
+    )
+  );
+
+  // Source of all web3studio members as an array of IDs
+  const web3studioMembers = from(
+    organizationTeamMembers('consensys', 'web3studio')
+  ).pipe(map(users => users.map(user => user.node.id)));
+
+  // Add `group` based on known github organizations and teams
+  return combineLatest(source, consensysMembers, web3studioMembers).pipe(
+    map(([event, consensys, web3studio]) => {
+      const user = event.meta.user;
+      let group = '';
+
+      if (!user) {
+        return event;
+      }
+
+      if (web3studio.includes(user.id)) {
+        group = 'web3studio';
+      } else if (consensys.includes(user.id)) {
+        group = 'consensys';
+      } else {
+        group = 'other';
+      }
+
+      event.meta.user.group = group;
+
+      return event;
+    })
+  );
+};

--- a/packages/github-collector/src/collector.js
+++ b/packages/github-collector/src/collector.js
@@ -5,6 +5,7 @@ const elasticTransport = require('./elasticTransport');
 const collectRepos = require('./collectRepos');
 const collectStargazers = require('./collectStargazers');
 const collectForks = require('./collectForks');
+const annotateUsers = require('./annotateUsers');
 
 module.exports = async function collect() {
   const logger = winston.createLogger({
@@ -14,6 +15,7 @@ module.exports = async function collect() {
   collectRepos()
     .pipe(
       publish(repos => merge(collectStargazers(repos), collectForks(repos))),
+      annotateUsers(),
       finalize(() => {
         logger.end();
       })

--- a/packages/github-collector/src/queries/organizationMembers.js
+++ b/packages/github-collector/src/queries/organizationMembers.js
@@ -1,0 +1,35 @@
+const { id: gql } = require('common-tags');
+const { queryAll } = require('./client');
+const { paging } = require('./fragements');
+
+const query = gql`
+  query repositories(
+    $login: String!
+    $count: Int = 100
+    $cursor: String = null
+  ) {
+    organization(login: $login) {
+      membersWithRole(first: $count, after: $cursor) {
+        pageInfo {
+          ...paging
+        }
+        edges {
+          cursor
+          node {
+            id
+            login
+          }
+        }
+      }
+    }
+  }
+
+  ${paging}
+`;
+
+module.exports = (login = 'Consensys') =>
+  queryAll({
+    query,
+    variables: { login },
+    selector: ({ organization }) => organization.membersWithRole
+  });

--- a/packages/github-collector/src/queries/organizationTeamMembers.js
+++ b/packages/github-collector/src/queries/organizationTeamMembers.js
@@ -1,0 +1,40 @@
+const { id: gql } = require('common-tags');
+const { queryAll } = require('./client');
+const { paging } = require('./fragements');
+
+const query = gql`
+  query repositories(
+    $login: String!
+    $slug: String!
+    $count: Int = 100
+    $cursor: String = null
+  ) {
+    organization(login: $login) {
+      team(slug: $slug) {
+        members(first: $count, after: $cursor) {
+          pageInfo {
+            ...paging
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ${paging}
+`;
+
+module.exports = (login, slug) =>
+  queryAll({
+    query,
+    variables: {
+      login,
+      slug
+    },
+    selector: ({ organization }) => organization.team.members
+  });


### PR DESCRIPTION
**Related Issue**  
Supports #1

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Adds a `user.group` to users in events based on if they're in a Consensys github org and if they're a member of web3studios

**Description of Changes**  
Just lots o'data ingestion and mapping

**What gif most accurately describes how I feel towards this PR?**  
![](https://media0.giphy.com/media/4NcStuYDAkLmAqAZxH/200w.gif?cid=5a38a5a25ca64a0746384a362e831040)

