### PR TITLE
Allow the graphql client to accept query params

### DIFF
--- a/packages/github-collector/src/queries/client.js
+++ b/packages/github-collector/src/queries/client.js
@@ -1,4 +1,5 @@
 const doWhilst = require('p-do-whilst');
+const _ = require('lodash');
 
 require('dotenv').config();
 
@@ -17,8 +18,8 @@ const graphql = require('@octokit/graphql').defaults({
  * @param {Object} ops.variables - Variables for the query
  * @returns {Promise<Array>} Results of the query
  */
-const queryAll = async ({ query, selector, variables }) => {
-  let currentCursor = null;
+const queryAll = async ({ query, selector, variables = {} }) => {
+  let currentCursor = variables.cursor || null;
   let data = [];
 
   await doWhilst(
@@ -32,7 +33,7 @@ const queryAll = async ({ query, selector, variables }) => {
 
       data = data.concat(selected.edges);
 
-      currentCursor = selected.pageInfo.hasNextPage
+      currentCursor = _.get(selected, 'pageInfo.hasNextPage', false)
         ? selected.pageInfo.endCursor
         : null;
     },

--- a/packages/github-collector/src/queries/client.test.js
+++ b/packages/github-collector/src/queries/client.test.js
@@ -1,8 +1,8 @@
 const fetchMock = require('node-fetch').default;
 
 const mockGithub = require('../../test/fixtures/mockGithub');
-const organizationRepositories = require('./organizationRepositories');
-const organizationRepositoriesFixture = require('../../test/fixtures/organizationRepositories');
+const repositoryForks = require('./repositoryForks');
+const repositoryForksFixture = require('../../test/fixtures/repositoryForks');
 
 describe('The github Client', () => {
   afterEach(() => {
@@ -10,24 +10,50 @@ describe('The github Client', () => {
   });
 
   it('Pages through query results', async () => {
-    const firstResult = organizationRepositoriesFixture();
+    const firstResult = repositoryForksFixture();
+    const secondResult = repositoryForksFixture();
 
     fetchMock.post((url, opts) => {
       const body = JSON.parse(opts.body);
 
       return !!body.variables.cursor;
-    }, organizationRepositoriesFixture());
+    }, secondResult);
 
-    firstResult.data.organization.repositories.pageInfo.hasNextPage = true;
-    fetchMock.post(
-      mockGithub.matchQuery('organizationRepositories'),
-      firstResult
-    );
+    firstResult.data.repository.forks.pageInfo.hasNextPage = true;
+    fetchMock.post(mockGithub.matchQuery('repositoryForks'), firstResult);
 
-    const results = await organizationRepositories();
+    const results = await repositoryForks();
 
     expect(results.length).toEqual(
-      firstResult.data.organization.repositories.edges.length * 2
+      firstResult.data.repository.forks.edges.length +
+        secondResult.data.repository.forks.edges.length
+    );
+  });
+
+  it('Allows a starting cursor to be passed', async () => {
+    const firstCursor = 'firstCursor';
+    const firstResult = repositoryForksFixture();
+    const secondResult = repositoryForksFixture();
+
+    firstResult.data.repository.forks.pageInfo.hasNextPage = true;
+
+    fetchMock.post((url, opts) => {
+      const body = JSON.parse(opts.body);
+
+      return body.variables.cursor === firstCursor;
+    }, firstResult);
+
+    fetchMock.post((url, opts) => {
+      const body = JSON.parse(opts.body);
+
+      return body.variables.cursor !== firstCursor;
+    }, secondResult);
+
+    const results = await repositoryForks({ cursor: firstCursor });
+
+    expect(results.length).toEqual(
+      firstResult.data.repository.forks.edges.length +
+        secondResult.data.repository.forks.edges.length
     );
   });
 });


### PR DESCRIPTION
**Related Issue**  
Supports #1

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Allows the graphql client to accept a cursor as a variable so it can pick up where it left off. 

**Description of Changes**  
Handling above and tests.

**What gif most accurately describes how I feel towards this PR?**  
![](https://media2.giphy.com/media/LXHJRRjnviw7e/200w.gif?cid=5a38a5a25cb5f06442354e4841c1053e)
